### PR TITLE
fix: Suppress Anki warning

### DIFF
--- a/src/reset_card_scheduling/main.py
+++ b/src/reset_card_scheduling/main.py
@@ -17,6 +17,7 @@ from aqt import mw
 from aqt.utils import askUser, tooltip
 from aqt.browser import Browser
 from anki.hooks import addHook
+from anki.lang import _
 
 from .consts import anki21
 


### PR DESCRIPTION
Adding ``from anki.lang import _`` to ``main.py`` suppresses the following Anki warning when using your plugin in the Anki Browser:

```
accessing _ without importing from anki.lang will break in the future
  File "/home/trevorld/a/sync/Dropbox/Anki/addons21/300884351/main.py", line 51, in onBrowserResetCards
    self.mw.checkpoint(_("Reset scheduling and learning on selected cards"))
```
