### PR TITLE
Change version check to new system

### DIFF
--- a/src/reset_card_scheduling/consts.py
+++ b/src/reset_card_scheduling/consts.py
@@ -11,10 +11,11 @@ License: GNU AGPLv3 <https://www.gnu.org/licenses/agpl.html>
 
 import sys
 import os
-from anki import version
+from anki.utils import pointVersion
 
-anki21 = version.startswith("2.1.")
 sys_encoding = sys.getfilesystemencoding()
+
+anki21 = pointVersion() > 0
 
 if anki21:
     addon_path = os.path.dirname(__file__)


### PR DESCRIPTION
Changes the version check from the deprecated Anki version string comparison to the new pointVersion() to fix issues when updating from Anki 2.1.x to 23.x

Fixes Issue #3.